### PR TITLE
fix the problem that LanguageDidChangeNotification is posted earlier than setting value of self.currentLanguage 

### DIFF
--- a/LanguagesManager/LanguagesManager/LanguagesManager/LanguagesManager.m
+++ b/LanguagesManager/LanguagesManager/LanguagesManager/LanguagesManager.m
@@ -107,8 +107,8 @@ NSString * const LanguagesManagerLanguageDidChangeNotification = @"LanguagesMana
     
     if ([self isAnAvailableLanguage:language]) {
         NSString *path = [[NSBundle mainBundle] pathForResource:language ofType:@"lproj" ];
-        self.bundle = [NSBundle bundleWithPath:path];
         self.currentLanguage = language;
+        self.bundle = [NSBundle bundleWithPath:path];
         NSString *languagekey = [NSString stringWithFormat:@"%@_for_%@",LanguagesManagerAppleLanguagesKey,login];
         
         NSMutableArray* customLanguagesOrder = [[[NSUserDefaults standardUserDefaults] objectForKey:languagekey] mutableCopy];


### PR DESCRIPTION
fix the problem that LanguagesManagerLanguageDidChangeNotification is posted earlier before setting value of self.currentLanguage
